### PR TITLE
Fix Airbyte image

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,8 @@ resource "docker_container" "airflow" {
 }
 
 resource "docker_image" "airbyte" {
-  name         = "airbyte/airbyte:0.50.6"
+  # Versão pública estável conforme documentação do projeto
+  name         = "airbyte/airbyte:0.50.38"
   keep_locally = false
 }
 


### PR DESCRIPTION
## Summary
- update Airbyte docker image to public stable version

## Testing
- `terraform fmt -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684366fc90e48330bf5b7241a9c6a86c