### PR TITLE
Atualiza imagem do dbt para versão 1.8.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ make clean-volumes → Remove volumes persistentes
 Observações
 -----------
 - O Airbyte usa imagens fixas na versão 0.50.38 por estabilidade.
+- O container do dbt foi atualizado para a versão 1.8.8.
 - Os caminhos montados no Airflow e dbt usam bind com `abspath()` no Terraform (funciona apenas com caminhos absolutos).
 - Todos os containers compartilham a rede local criada pelo Terraform para facilitar a comunicação entre serviços.
 

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,8 @@ resource "docker_container" "postgres" {
 }
 
 resource "docker_image" "dbt" {
-  name         = "fishtownanalytics/dbt:1.0.0"
+  # Atualizado para a versão mais recente do dbt
+  name         = "ghcr.io/dbt-labs/dbt-core:1.8.8"
   keep_locally = false
 }
 


### PR DESCRIPTION
## Summary
- update dbt docker image to version 1.8.8
- document the new dbt version in the README

## Testing
- `terraform fmt -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684369e30b8c8330a6f6c242e6f466b2