### PR TITLE
Add default Airflow admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Como usar
 
 3. Acesse os serviços:
 
-   - Airflow:      http://localhost:8080
+   - Airflow:      http://localhost:8080 (login: admin / admin)
    - dbt (exec):   make dbt-run
 
 Comandos Makefile úteis

--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,10 @@ resource "docker_container" "airflow" {
     host_path      = abspath("${path.module}/orchestrate/dags")
     container_path = "/opt/airflow/dags"
   }
-  command = ["bash", "-c", "airflow db init && airflow webserver"]
+  command = [
+    "bash",
+    "-c",
+    "airflow db init && airflow users create --username admin --password admin --firstname admin --lastname admin --role Admin --email admin@example.com || true && airflow webserver"
+  ]
 }
 


### PR DESCRIPTION
## Summary
- automate admin user creation when the Airflow container starts
- document default credentials in the README

## Testing
- `terraform fmt -check` *(fails: terraform not installed)*
- `make -n up` *(fails: Makefile parse error)*

------
https://chatgpt.com/codex/tasks/task_e_6843792e1eb4833089466a055513c618