### PR TITLE
Add sample dbt project and airflow dag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Pré-requisitos
 
 Estrutura do Projeto
 --------------------
-- orchestrate/dags         → Código dos DAGs do Airflow
-- transforms/              → Projetos dbt
-- terraform/               → Arquivos .tf (infraestrutura)
+ - orchestrate/dags         → Código dos DAGs do Airflow
+ - dbt/                     → Projeto dbt com modelos e configurações
+ - terraform/               → Arquivos .tf (infraestrutura)
 - Makefile                 → Comandos utilitários
 
 Como usar
@@ -64,3 +64,10 @@ Manutenção
 ----------
 - Atualize as imagens com cuidado (ex: Airflow e dbt têm dependências fixas).
 - Recomenda-se limpar volumes (`make clean-volumes`) ao trocar dados sensíveis como senhas ou nomes de bancos.
+
+Testes de exemplo
+-----------------
+Este repositório inclui um modelo dbt simples e uma DAG de teste que sao
+criados pelo Terraform. Os arquivos finais sao gravados em
+`dbt/models/test_model.sql` e `orchestrate/dags/test_dag.py` por recursos
+`local_file`. A DAG executa o comando `dbt run` no container do dbt.

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -1,0 +1,7 @@
+name: test_project
+dbt_version: 1.0.0
+config-version: 2
+
+model-paths: ["models"]
+
+profile: test_project

--- a/dbt/models/test_model.sql
+++ b/dbt/models/test_model.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -1,0 +1,11 @@
+test_project:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: postgres
+      user: admin
+      password: admin
+      dbname: warehouse
+      port: 5432
+      schema: public

--- a/orchestrate/dags/test_dag.py
+++ b/orchestrate/dags/test_dag.py
@@ -1,0 +1,15 @@
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from datetime import datetime
+
+with DAG(
+    dag_id="dbt_test_dag",
+    start_date=datetime(2024, 1, 1),
+    schedule_interval="@daily",
+    catchup=False,
+) as dag:
+    run_dbt = BashOperator(
+        task_id="run_dbt",
+        bash_command="docker exec -t dbt_airflow_project_dbt dbt run --project-dir /usr/app"
+    )
+


### PR DESCRIPTION
## Summary
- include a minimal dbt project with a test model and profile
- add a sample Airflow DAG that runs the dbt container
- start the scheduler alongside the webserver
- document the new test resources in the README
- manage the DAG and dbt files via Terraform local_file resources

## Testing
- ❌ `terraform fmt -check` *(failed: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68438168a96083309e89716e14e48eb8